### PR TITLE
docker: add libconfig as a build dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN set -xe \
         automake \
         gdb \
         gengetopt \
+        libconfig-dev \
         libmicrohttpd-dev \
         libnice-dev \
         libssl-dev \


### PR DESCRIPTION
This is need to build more recent Janus releases.